### PR TITLE
Add voltage conversion methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ lib_deps =
 AD7606p16_t4 adc(RD_PIN, CS_PIN, CONV_PIN, BUSY_PIN, RESET_PIN);
 
 int16_t channels[8];
+float voltages[8];
 
 void loop() {
-    adc.getData(channels);  // Get latest readings
+    adc.getData(channels);      // Get raw 16-bit readings
+    adc.getVoltages(voltages);  // Get all voltages at once
+    
+    float ch0_voltage = adc.getVoltage(0);  // Get single channel voltage
 }
 ```
 
@@ -100,6 +104,35 @@ for (int i = 0; i < 16; i++) {
 data = (GPIO6_PSR >> 16) & 0b1111111111111111; // Read D0-D15 from GPIO6
 // Extract bits with optimized operations
 ```
+
+## API Reference
+
+### Methods
+
+#### `void getData(int16_t* data)`
+Gets raw 16-bit ADC readings for all 8 channels.
+- **Parameters**: `data` - Array of 8 int16_t values to store readings
+- **Returns**: None
+- **Thread-safe**: Yes (uses interrupt disabling)
+
+#### `float getVoltage(uint8_t channel)`
+Gets voltage reading for a single channel.
+- **Parameters**: `channel` - Channel number (0-7)
+- **Returns**: Voltage as float (assumes 5V reference)
+- **Thread-safe**: Yes (uses interrupt disabling)
+- **Note**: Returns 0.0f for invalid channel numbers
+
+#### `void getVoltages(float* voltages)`
+Gets voltage readings for all 8 channels at once.
+- **Parameters**: `voltages` - Array of 8 float values to store voltages
+- **Returns**: None
+- **Thread-safe**: Yes (uses interrupt disabling)
+- **Note**: Assumes 5V reference voltage
+
+#### `void reset()`
+Performs hardware reset of the AD7606.
+- **Parameters**: None
+- **Returns**: None
 
 ## Performance Goals
 

--- a/examples/BasicReading/BasicReading.ino
+++ b/examples/BasicReading/BasicReading.ino
@@ -35,6 +35,7 @@ AD7606p16_t4 adc(RD_PIN, CS_PIN, CONV_START_PIN, BUSY_PIN, RESET_PIN);
 
 // Buffer to hold channel data
 int16_t channelData[8];
+float voltageData[8];
 
 // Timing variables
 unsigned long lastPrint = 0;
@@ -53,6 +54,7 @@ void setup() {
 void loop() {
     // Read data from AD7606 (non-blocking, ISR-driven)
     adc.getData(channelData);
+    adc.getVoltages(voltageData);
     loopCount++;
     
     // Print results every second
@@ -60,9 +62,16 @@ void loop() {
         Serial.print("Loops/sec: ");
         Serial.println(loopCount);
         
-        Serial.print("Raw values: ");
+        Serial.print("Voltages (V): ");
         for (int i = 0; i < 8; i++) {
-            Serial.print((channelData[i] * 5.0f) / 32768.0f, 3); // Convert to voltage (assuming 5V reference);
+            Serial.print(voltageData[i], 3);
+            if (i < 7) Serial.print(", ");
+        }
+        Serial.println();
+        
+        Serial.print("Individual voltage reads: ");
+        for (int i = 0; i < 8; i++) {
+            Serial.print(adc.getVoltage(i), 3);
             if (i < 7) Serial.print(", ");
         }
         Serial.println();

--- a/src/AD7606p16_t4.cpp
+++ b/src/AD7606p16_t4.cpp
@@ -138,3 +138,21 @@ void AD7606p16_t4::getData(int16_t* data) {
     }
     interrupts(); // Re-enable interrupts
 }
+
+float AD7606p16_t4::getVoltage(uint8_t channel) {
+    if (channel >= 8) return 0.0f; // Invalid channel
+    
+    noInterrupts(); // Disable interrupts to ensure atomic read
+    int16_t rawValue = instance->channels[channel];
+    interrupts(); // Re-enable interrupts
+    
+    return (rawValue * 5.0f) / 32768.0f;
+}
+
+void AD7606p16_t4::getVoltages(float* voltages) {
+    noInterrupts(); // Disable interrupts to ensure atomic read
+    for (uint8_t i = 0; i < 8; i++) {
+        voltages[i] = (instance->channels[i] * 5.0f) / 32768.0f;
+    }
+    interrupts(); // Re-enable interrupts
+}

--- a/src/AD7606p16_t4.h
+++ b/src/AD7606p16_t4.h
@@ -5,6 +5,8 @@ class AD7606p16_t4 {
     public:
         AD7606p16_t4(uint8_t RD, uint8_t CS, uint8_t CONVERSION_START, uint8_t BUSY, uint8_t RESET);
         void getData(int16_t* data);
+        float getVoltage(uint8_t channel);
+        void getVoltages(float* voltages);
         void reset();
 
     private:


### PR DESCRIPTION
## Summary
- Add `getVoltage(channel)` method for single channel voltage reading
- Add `getVoltages()` method for all channel voltage readings at once
- Update BasicReading example to demonstrate new voltage methods
- Update README.md with comprehensive API documentation

## Test plan
- [ ] Verify library compiles without errors
- [ ] Test getVoltage() method with valid channel numbers (0-7)
- [ ] Test getVoltage() method with invalid channel numbers (returns 0.0f)
- [ ] Test getVoltages() method returns array of 8 voltage values
- [ ] Verify example sketch compiles and runs correctly
- [ ] Confirm voltage conversion formula matches expected values (5V reference)

🤖 Generated with [Claude Code](https://claude.ai/code)